### PR TITLE
Added option to send multiple attachements on both iOS and Android.

### DIFF
--- a/android/src/main/kotlin/com/sidlatau/flutteremailsender/FlutterEmailSenderPlugin.kt
+++ b/android/src/main/kotlin/com/sidlatau/flutteremailsender/FlutterEmailSenderPlugin.kt
@@ -93,6 +93,7 @@ class FlutterEmailSenderPlugin(private val registrar: Registrar)
                 intent.putExtra(Intent.EXTRA_BCC, listArrayToArray(bcc))
             }
         }
+
         if (options.hasArgument(ATTACHMENT_PATHS)) {
             val attachmentPaths = options.argument<ArrayList<String>>(ATTACHMENT_PATHS)
             if (attachmentPaths != null) {
@@ -100,9 +101,14 @@ class FlutterEmailSenderPlugin(private val registrar: Registrar)
                 val uris = attachmentPaths.map {
                     FileProvider.getUriForFile(activity, registrar.context().packageName + ".file_provider", File(it))
                 }
-                intent.action = Intent.ACTION_SEND_MULTIPLE
                 intent.type = "vnd.android.cursor.dir/email"
-                intent.putParcelableArrayListExtra(Intent.EXTRA_STREAM, ArrayList(uris))
+                if (uris.count() == 1) {
+                    intent.action = Intent.ACTION_SEND
+                    intent.putExtra(Intent.EXTRA_STREAM, uris.first())
+                } else {
+                    intent.action = Intent.ACTION_SEND_MULTIPLE
+                    intent.putParcelableArrayListExtra(Intent.EXTRA_STREAM, ArrayList(uris))
+                }
             }
         }
 

--- a/android/src/main/kotlin/com/sidlatau/flutteremailsender/FlutterEmailSenderPlugin.kt
+++ b/android/src/main/kotlin/com/sidlatau/flutteremailsender/FlutterEmailSenderPlugin.kt
@@ -17,7 +17,7 @@ private const val BODY = "body"
 private const val RECIPIENTS = "recipients"
 private const val CC = "cc"
 private const val BCC = "bcc"
-private const val ATTACHMENT_PATH = "attachment_path"
+private const val ATTACHMENT_PATHS = "attachment_paths"
 private const val IS_HTML = "is_html"
 private const val REQUEST_CODE_SEND = 607
 
@@ -93,18 +93,16 @@ class FlutterEmailSenderPlugin(private val registrar: Registrar)
                 intent.putExtra(Intent.EXTRA_BCC, listArrayToArray(bcc))
             }
         }
-
-        if (options.hasArgument(ATTACHMENT_PATH)) {
-            val attachmentPath = options.argument<String>(ATTACHMENT_PATH)
-            if (attachmentPath != null) {
+        if (options.hasArgument(ATTACHMENT_PATHS)) {
+            val attachmentPaths = options.argument<ArrayList<String>>(ATTACHMENT_PATHS)
+            if (attachmentPaths != null) {
                 intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-
-                val file = File(attachmentPath)
-                val uri = FileProvider.getUriForFile(activity, registrar.context().packageName + ".file_provider", file)
-
-                intent.action = Intent.ACTION_SEND
+                val uris = attachmentPaths.map {
+                    FileProvider.getUriForFile(activity, registrar.context().packageName + ".file_provider", File(it))
+                }
+                intent.action = Intent.ACTION_SEND_MULTIPLE
                 intent.type = "vnd.android.cursor.dir/email"
-                intent.putExtra(Intent.EXTRA_STREAM, uri)
+                intent.putParcelableArrayListExtra(Intent.EXTRA_STREAM, ArrayList(uris))
             }
         }
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -13,7 +13,7 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> {
-  String attachment;
+  List<String> attachments = [];
   bool isHTML = false;
 
   final _recipientController = TextEditingController(
@@ -33,7 +33,7 @@ class _MyAppState extends State<MyApp> {
       body: _bodyController.text,
       subject: _subjectController.text,
       recipients: [_recipientController.text],
-      attachmentPath: attachment,
+      attachmentPaths: attachments,
       isHTML: isHTML,
     );
 
@@ -55,8 +55,6 @@ class _MyAppState extends State<MyApp> {
 
   @override
   Widget build(BuildContext context) {
-    final Widget imagePath = Text(attachment ?? '');
-
     return MaterialApp(
       theme: ThemeData(primaryColor: Colors.red),
       home: Scaffold(
@@ -117,7 +115,23 @@ class _MyAppState extends State<MyApp> {
                     },
                     value: isHTML,
                   ),
-                  imagePath,
+                  ListView.builder(
+                      shrinkWrap: true,
+                      itemCount: attachments.length,
+                      itemBuilder: (BuildContext context, int index) {
+                        return Row(
+                          children: <Widget>[
+                            Text((index + 1).toString()),
+                            SizedBox(width: 5),
+                            Expanded(
+                              child: Text(
+                                attachments[index],
+                                overflow: TextOverflow.fade,
+                              ),
+                            ),
+                          ],
+                        );
+                      }),
                 ],
               ),
             ),
@@ -135,7 +149,7 @@ class _MyAppState extends State<MyApp> {
   void _openImagePicker() async {
     File pick = await ImagePicker.pickImage(source: ImageSource.gallery);
     setState(() {
-      attachment = pick.path;
+      attachments.add(pick.path);
     });
   }
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -115,23 +115,25 @@ class _MyAppState extends State<MyApp> {
                     },
                     value: isHTML,
                   ),
-                  ListView.builder(
-                      shrinkWrap: true,
-                      itemCount: attachments.length,
-                      itemBuilder: (BuildContext context, int index) {
-                        return Row(
-                          children: <Widget>[
-                            Text((index + 1).toString()),
-                            SizedBox(width: 5),
-                            Expanded(
-                              child: Text(
-                                attachments[index],
-                                overflow: TextOverflow.fade,
+                  Container(
+                    height: (attachments.length * 50).toDouble(),
+                    child: ListView.builder(
+                        itemCount: attachments.length,
+                        itemBuilder: (BuildContext context, int index) {
+                          return Row(
+                            children: <Widget>[
+                              Text((index + 1).toString()),
+                              SizedBox(width: 5),
+                              Expanded(
+                                child: Text(
+                                  attachments[index],
+                                  overflow: TextOverflow.fade,
+                                ),
                               ),
-                            ),
-                          ],
-                        );
-                      }),
+                            ],
+                          );
+                        }),
+                  ),
                 ],
               ),
             ),

--- a/ios/Classes/SwiftFlutterEmailSenderPlugin.swift
+++ b/ios/Classes/SwiftFlutterEmailSenderPlugin.swift
@@ -46,13 +46,16 @@ public class SwiftFlutterEmailSenderPlugin: NSObject, FlutterPlugin {
                 mailComposerVC.setMessageBody(body, isHTML: email.isHTML ?? false)
             }
 
-            if let attachmentPath = email.attachmentPath,
-                let fileData = try? Data(contentsOf: URL(fileURLWithPath: attachmentPath)) {
-                mailComposerVC.addAttachmentData(
-                    fileData,
-                    mimeType: "application/octet-stream",
-                    fileName: (attachmentPath as NSString).lastPathComponent
-                )
+            if let attachmentPaths = email.attachmentPaths {
+                for path in attachmentPaths {
+                    if let fileData = try? Data(contentsOf: URL(fileURLWithPath: path)) {
+                        mailComposerVC.addAttachmentData(
+                            fileData,
+                            mimeType: "application/octet-stream",
+                            fileName: (path as NSString).lastPathComponent
+                        )
+                    }
+                }
             }
 
             viewController.present(mailComposerVC,
@@ -81,7 +84,7 @@ public class SwiftFlutterEmailSenderPlugin: NSObject, FlutterPlugin {
             cc: args[Email.CC] as? [String],
             bcc: args[Email.BCC] as? [String],
             body: args[Email.BODY] as? String,
-            attachmentPath: args[Email.ATTACHMENT_PATH] as? String,
+            attachmentPaths: args[Email.ATTACHMENT_PATHS] as? [String],
             subject: args[Email.SUBJECT] as? String,
             isHTML:args[Email.IS_HTML] as? Bool
         )
@@ -100,14 +103,14 @@ struct Email {
     static let RECIPIENTS = "recipients"
     static let CC = "cc"
     static let BCC = "bcc"
-    static let ATTACHMENT_PATH = "attachment_path"
+    static let ATTACHMENT_PATHS = "attachment_paths"
     static let IS_HTML = "is_html"
 
     let recipients: [String]?
     let cc: [String]?
     let bcc: [String]?
     let body: String?
-    let attachmentPath: String?
+    let attachmentPaths: [String]?
     let subject: String?
     let isHTML: Bool?
 }

--- a/lib/flutter_email_sender.dart
+++ b/lib/flutter_email_sender.dart
@@ -17,7 +17,7 @@ class Email {
   final List<String> cc;
   final List<String> bcc;
   final String body;
-  final String attachmentPath;
+  final List<String> attachmentPaths;
   final bool isHTML;
   Email({
     this.subject = '',
@@ -25,7 +25,7 @@ class Email {
     this.cc = const [],
     this.bcc = const [],
     this.body = '',
-    this.attachmentPath,
+    this.attachmentPaths,
     this.isHTML = false,
   });
 
@@ -36,7 +36,7 @@ class Email {
       'recipients': recipients,
       'cc': cc,
       'bcc': bcc,
-      'attachment_path': attachmentPath,
+      'attachment_paths': attachmentPaths,
       'is_html': isHTML
     };
   }


### PR DESCRIPTION
I've added the feature of adding and sending multiple attachments, as the possibility to attach just one file was annoying. 
That also kind of solves the problem of sending .zip files on Android (as Gmail does not allow to attach .zips) - now it's possible to just attach more than 1 file instead of zipping a couple of them together.