### PR TITLE
[Android] Fixing the Future never successfully finishing

### DIFF
--- a/android/src/main/kotlin/com/sidlatau/flutteremailsender/FlutterEmailSenderPlugin.kt
+++ b/android/src/main/kotlin/com/sidlatau/flutteremailsender/FlutterEmailSenderPlugin.kt
@@ -47,7 +47,7 @@ class FlutterEmailSenderPlugin
 
     override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
         val channel = MethodChannel(binding.binaryMessenger, methodChannelName)
-        channel.setMethodCallHandler(FlutterEmailSenderPlugin())
+        channel.setMethodCallHandler(this)
     }
 
     override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
@@ -75,10 +75,10 @@ class FlutterEmailSenderPlugin
 
     override fun onMethodCall(call: MethodCall, result: Result) {
         if (call.method == "send") {
-            sendEmail(call, result)
             // If the call threw an exception, Flutter already sent a result to the channel,
             // so we don't need to send a result from onActivityResult anymore.
             this.channelResult = result
+            sendEmail(call, result)
         } else {
             result.notImplemented()
         }


### PR DESCRIPTION
Seems like the problem was caused by:
- not remembering the `Result` before `sendEmail` was called
- creating a new instance of `FlutterEmailSenderPlugin` every time `onAttachedToEngine` was called. Instead, reusing the same instance of the plugin makes sure that the `Result` is set correctly when `onActivityResult` is called