### PR TITLE
[Android] Fixing and refactoring the way email body text is assigned to the Intent

### DIFF
--- a/android/src/main/kotlin/com/sidlatau/flutteremailsender/FlutterEmailSenderPlugin.kt
+++ b/android/src/main/kotlin/com/sidlatau/flutteremailsender/FlutterEmailSenderPlugin.kt
@@ -118,24 +118,15 @@ class FlutterEmailSenderPlugin
         if (attachmentUris.size == 0) {
             intent.action = Intent.ACTION_SENDTO
             intent.data = Uri.parse("mailto:")
-            if (text != null) {
-                intent.putExtra(Intent.EXTRA_TEXT, text)
-            }
         } else {
             intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
 
             if (attachmentUris.size == 1) {
                 intent.action = Intent.ACTION_SEND
                 intent.putExtra(Intent.EXTRA_STREAM, attachmentUris.first())
-                if (text != null) {
-                    intent.putExtra(Intent.EXTRA_TEXT, text)
-                }
             } else {
                 intent.action = Intent.ACTION_SEND_MULTIPLE
                 intent.putParcelableArrayListExtra(Intent.EXTRA_STREAM, ArrayList(attachmentUris))
-                if (text != null) {
-                    intent.putCharSequenceArrayListExtra(Intent.EXTRA_TEXT, arrayListOf(text))
-                }
             }
 
             // Add a selector intent to make sure that only email apps are shown, instead of just any app that can
@@ -154,6 +145,10 @@ class FlutterEmailSenderPlugin
                 clipData.addItem(item)
             }
             intent.clipData = clipData
+        }
+
+        if (text != null) {
+            intent.putExtra(Intent.EXTRA_TEXT, text)
         }
 
         if (html != null) {


### PR DESCRIPTION
- before, the email body was not correctly set to the Intent when multiple attachments were set
- changing that part of the code resulted in repeating the same code to set email body in three places so I refactore the method a bit to only need one `if` that causes the text to be set to the Intent