### PR TITLE
 Add Java 1.8 compile options and Kotlin JVM target in build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -28,6 +28,15 @@ android {
     compileSdkVersion 33
     namespace "com.sidlatau.flutteremailsender"
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }


### PR DESCRIPTION
This commit introduces specific compile options for the Android build.

Both the source and target compatibility have been set to Java Version 1.8. Additionally, the Kotlin JVM target has been set to '1.8'.

These changes ensure that the project aligns with the necessary Java and Kotlin compatibility levels.