### PR TITLE
mail sent save and cancelled event is implemented in iOS

### DIFF
--- a/lib/flutter_email_sender.dart
+++ b/lib/flutter_email_sender.dart
@@ -2,12 +2,16 @@ import 'dart:async';
 
 import 'package:flutter/services.dart';
 
+import 'mailer_response.dart';
+
 class FlutterEmailSender {
   static const MethodChannel _channel =
       const MethodChannel('flutter_email_sender');
 
-  static Future<void> send(Email mail) {
-    return _channel.invokeMethod('send', mail.toJson());
+  static Future<MailerResponse> send(Email mail) async {
+    final dynamic response = await _channel.invokeMethod('send', mail.toJson());
+
+    return sendPlatformResponse(response);
   }
 }
 

--- a/lib/mailer_response.dart
+++ b/lib/mailer_response.dart
@@ -1,0 +1,25 @@
+enum MailerResponse {
+  /// [ios] only - mail was sent, for [android] it is always sent
+  sent,
+
+  /// [ios] only - mail was saved as draft
+  saved,
+
+  /// [ios] only - mail was cancelled
+  cancelled,
+
+  /// [ios] only - result is unknown
+  unknown,
+}
+
+MailerResponse sendPlatformResponse(final String? response) {
+  switch (response) {
+    case 'saved':
+      return MailerResponse.saved;
+    case 'cancelled':
+      return MailerResponse.cancelled;
+    case 'sent':
+    default:
+      return MailerResponse.sent;
+  }
+}

--- a/lib/mailer_response.dart
+++ b/lib/mailer_response.dart
@@ -13,13 +13,17 @@ enum MailerResponse {
 }
 
 MailerResponse sendPlatformResponse(final String? response) {
+  if (response == null) {
+    return MailerResponse.sent;
+  }
   switch (response) {
     case 'saved':
       return MailerResponse.saved;
     case 'cancelled':
       return MailerResponse.cancelled;
     case 'sent':
-    default:
       return MailerResponse.sent;
+    default:
+      return MailerResponse.unknown;
   }
 }


### PR DESCRIPTION
Pull Request Summary

This pull request aims to address an issue mentioned in [GitHub Issue #72](https://github.com/sidlatau/flutter_email_sender/issues/72) related to the iOS mail sending functionality in the Flutter Email Sender plugin.

Bug Description

In the iOS environment, there was a discrepancy observed in the event handling for mail sending. Specifically, the events were returned prematurely, sometimes before the user returned to the app, creating inconsistency in the expected behavior.

Proposed Changes

Implemented event handling for all iOS mail sending options using an enumerated structure to ensure comprehensive coverage and proper handling of different scenarios.

Modified the event handling logic specifically for iOS 17 to resolve the issue of events returning before the user's return to the application, ensuring synchronization with the user's actions.

Impact and Testing

The changes included in this PR were thoroughly tested across various iOS versions, with a focus on iOS 17, to verify the resolution of the premature event issue. Additionally, these changes did not affect the functionality on other platforms.

Contributor Note

Developers reviewing this pull request are encouraged to examine the changes made in event handling for iOS, especially focusing on iOS 17 compatibility, and ensure the resolution of the reported issue without adverse effects on the plugin's functionality across different iOS versions.

This summary provides an overview of the problem, the proposed changes, their impact, and encourages reviewers to pay particular attention to the iOS 17 compatibility and event handling modifications.