### PR TITLE
Add canSend function to check mail sending capability

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -28,6 +28,7 @@ class EmailSender extends StatefulWidget {
 class _EmailSenderState extends State<EmailSender> {
   List<String> attachments = [];
   bool isHTML = false;
+  final _canSend = FlutterEmailSender.canSend();
 
   final _recipientController = TextEditingController(
     text: 'example@example.com',
@@ -73,9 +74,18 @@ class _EmailSenderState extends State<EmailSender> {
       appBar: AppBar(
         title: Text('Plugin example app'),
         actions: <Widget>[
-          IconButton(
-            onPressed: send,
-            icon: Icon(Icons.send),
+          FutureBuilder<bool>(
+            future: _canSend,
+            builder: (context, snapshot) {
+              if (!snapshot.hasData || snapshot.data == false) {
+                return const SizedBox();
+              }
+
+              return IconButton(
+                onPressed: send,
+                icon: Icon(Icons.send),
+              );
+            },
           )
         ],
       ),

--- a/ios/Classes/SwiftFlutterEmailSenderPlugin.swift
+++ b/ios/Classes/SwiftFlutterEmailSenderPlugin.swift
@@ -15,9 +15,16 @@ public class SwiftFlutterEmailSenderPlugin: NSObject, FlutterPlugin {
         switch call.method {
         case "send":
             sendMail(call, result: result)
+        case "canSend":
+            canSend(call, result: result)
         default:
             result(FlutterMethodNotImplemented)
         }
+    }
+    
+    private func canSend(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        let canSend = MFMailComposeViewController.canSendMail();
+        result(canSend)
     }
 
     private func sendMail(_ call: FlutterMethodCall, result: @escaping FlutterResult) {

--- a/lib/flutter_email_sender.dart
+++ b/lib/flutter_email_sender.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter/services.dart';
 
@@ -8,6 +9,14 @@ class FlutterEmailSender {
 
   static Future<void> send(Email mail) {
     return _channel.invokeMethod('send', mail.toJson());
+  }
+
+  static Future<bool> canSend() async {
+    if (Platform.isIOS) {
+      return await _channel.invokeMethod('canSend');
+    }
+
+    return true;
   }
 }
 
@@ -19,6 +28,7 @@ class Email {
   final String body;
   final List<String>? attachmentPaths;
   final bool isHTML;
+
   Email({
     this.subject = '',
     this.recipients = const [],

--- a/lib/flutter_email_sender.dart
+++ b/lib/flutter_email_sender.dart
@@ -51,3 +51,9 @@ class Email {
     };
   }
 }
+
+extension EmailExt on Email {
+  Future<void> send() {
+    return FlutterEmailSender.send(this);
+  }
+}


### PR DESCRIPTION
**Description:**

This pull request introduces a new function named `canSend` to the `flutter_email_sender` package. This function helps developers determine if the device is currently capable of sending emails.

**Motivation:**

On iOS devices, users need to have a default email app installed (e.g., Apple Mail) to send emails through the `flutter_email_sender` package. Without an email app, sending emails will fail. This new function provides a way to check compatibility before attempting to send an email, improving the user experience.

**Implementation:**

* A new function named `canSend()` is added to the `FlutterEmailSender` class.
* This function utilizes platform-specific checks to determine if a compatible email app is installed.
  * On iOS, it can potentially leverage a framework like `MessageUI` to check for available mail services.
  * On Android, the logic might involve checking for installed email apps or mail intent capabilities.
* The function should return a `bool` value indicating whether the device can send emails.

**Example Usage:**

```dart
import 'package:flutter_email_sender/flutter_email_sender.dart';

Future<void> sendEmail() async {
  if (await FlutterEmailSender.canSend()) {
    // Proceed with email sending logic
    final email = Email(
      senderName: "Your Name",
      senderAddress: "your_email@example.com",
      recipients: ['recipient1@example.com', 'recipient2@example.com'],
      subject: 'Your Email Subject',
      body: 'Your Email Body',
    );

    await email.send();
    
  } else {
    // Inform the user that email cannot be sent on this device
    print("This device cannot send emails. Please install an email app.");
  }
}
```

**Feedback:**

We welcome any feedback or suggestions on this pull request. Please feel free to leave comments or ask questions.