### PR TITLE
Add macOS plugin support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ In android it opens default mail app via intent.
 
 In iOS `MFMailComposeViewController` is used to compose an email.
 
+In macOS `NSSharingService` with `.composeEmail` is used to compose an email.
+The macOS implementation does not support `cc`, `bcc`, or `isHTML`.
+
 # Example
 
 ```dart

--- a/ios/flutter_email_sender.podspec
+++ b/ios/flutter_email_sender.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_email_sender'
-  s.version          = '0.0.1'
+  s.version          = '8.0.0'
   s.summary          = 'Allows send emails from flutter using native platform functionality.'
   s.description      = <<-DESC
 Allows send emails from flutter using native platform functionality.

--- a/macos/Classes/FlutterEmailSenderPlugin.swift
+++ b/macos/Classes/FlutterEmailSenderPlugin.swift
@@ -1,0 +1,79 @@
+import Cocoa
+import FlutterMacOS
+
+public class FlutterEmailSenderPlugin: NSObject, FlutterPlugin {
+    public static func register(with registrar: FlutterPluginRegistrar) {
+        let channel = FlutterMethodChannel(name: "flutter_email_sender", binaryMessenger: registrar.messenger)
+        let instance = FlutterEmailSenderPlugin()
+        registrar.addMethodCallDelegate(instance, channel: channel)
+    }
+
+    public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        switch call.method {
+        case "send":
+            sendMail(call, result: result)
+        default:
+            result(FlutterMethodNotImplemented)
+        }
+    }
+
+    private func sendMail(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        guard let email = parseArgs(call, result: result) else { return }
+        guard let service = NSSharingService(named: .composeEmail) else {
+            result(FlutterError(code: "not_available", message: "No email clients found!", details: nil))
+            return
+        }
+
+        service.recipients = email.recipients
+        if let subject = email.subject {
+            service.subject = subject
+        }
+
+        var items: [Any] = []
+        if let body = email.body, !body.isEmpty {
+            items.append(body)
+        }
+
+        if let attachmentPaths = email.attachmentPaths {
+            for path in attachmentPaths {
+                let url = URL(fileURLWithPath: path)
+                if FileManager.default.fileExists(atPath: url.path) {
+                    items.append(url)
+                }
+            }
+        }
+
+        if items.isEmpty {
+            items.append("")
+        }
+
+        service.perform(withItems: items)
+        result(nil)
+    }
+
+    private func parseArgs(_ call: FlutterMethodCall, result: @escaping FlutterResult) -> Email? {
+        guard let args = call.arguments as? [String: Any?] else {
+            result(FlutterError(code: "error", message: "args are not map!", details: nil))
+            return nil
+        }
+
+        return Email(
+            recipients: args[Email.recipients] as? [String],
+            body: args[Email.body] as? String,
+            attachmentPaths: args[Email.attachmentPaths] as? [String],
+            subject: args[Email.subject] as? String
+        )
+    }
+}
+
+private struct Email {
+    static let subject = "subject"
+    static let body = "body"
+    static let recipients = "recipients"
+    static let attachmentPaths = "attachment_paths"
+
+    let recipients: [String]?
+    let body: String?
+    let attachmentPaths: [String]?
+    let subject: String?
+}

--- a/macos/Resources/PrivacyInfo.xcprivacy
+++ b/macos/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/macos/flutter_email_sender.podspec
+++ b/macos/flutter_email_sender.podspec
@@ -1,0 +1,21 @@
+#
+# To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html.
+#
+Pod::Spec.new do |s|
+  s.name             = 'flutter_email_sender'
+  s.version          = '8.0.0'
+  s.summary          = 'Allows sending emails from Flutter using native platform functionality.'
+  s.description      = <<-DESC
+Allows sending emails from Flutter using native platform functionality.
+                       DESC
+  s.homepage         = 'https://github.com/sidlatau/flutter_email_sender'
+  s.license          = { :file => '../LICENSE' }
+  s.author           = { 'Your Company' => 'email@example.com' }
+  s.source           = { :path => '.' }
+  s.source_files = 'Classes/**/*'
+  s.dependency 'FlutterMacOS'
+  
+  s.platform = :osx, '10.13'
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
+  s.swift_version = '5.0'
+end

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,8 @@ flutter:
         pluginClass: FlutterEmailSenderPlugin
       ios:
         pluginClass: FlutterEmailSenderPlugin
+      macos:
+        pluginClass: FlutterEmailSenderPlugin
 
 environment:
   sdk: ">=2.12.0 <4.0.0"


### PR DESCRIPTION
Added macOS support using NSSharingService.

Known limitation: cc, bcc, and isHTML are not supported on macOS.
Attachments are supported and working.