### PR TITLE
fix: point method_channel podspec license at package's own LICENSE

### DIFF
--- a/packages/flutter_email_sender_method_channel/ios/flutter_email_sender_method_channel.podspec
+++ b/packages/flutter_email_sender_method_channel/ios/flutter_email_sender_method_channel.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
 Allows send emails from flutter using native platform functionality.
                        DESC
   s.homepage         = 'https://github.com/sidlatau/flutter_email_sender'
-  s.license          = { :file => '../../flutter_email_sender/LICENSE' }
+  s.license          = { :file => '../LICENSE' }
   s.author           = { 'sidlatau' => 'sidlatau@gmail.com' }
   s.source           = { :path => '.' }
   s.module_name      = 'flutter_email_sender_method_channel'

--- a/packages/flutter_email_sender_method_channel/macos/flutter_email_sender_method_channel.podspec
+++ b/packages/flutter_email_sender_method_channel/macos/flutter_email_sender_method_channel.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
 Allows send emails from flutter using native platform functionality.
                        DESC
   s.homepage         = 'https://github.com/sidlatau/flutter_email_sender'
-  s.license          = { :file => '../../flutter_email_sender/LICENSE' }
+  s.license          = { :file => '../LICENSE' }
   s.author           = { 'sidlatau' => 'sidlatau@gmail.com' }
   s.source           = { :path => '.' }
   s.module_name      = 'flutter_email_sender_method_channel'


### PR DESCRIPTION
## What

Fix the `license :file` path in the iOS and macOS podspecs for `flutter_email_sender_method_channel` so it points at the package's **own** bundled `LICENSE`.

```diff
- s.license = { :file => '../../flutter_email_sender/LICENSE' }
+ s.license = { :file => '../LICENSE' }
```

## Why

The current path resolves to the **sibling** `flutter_email_sender` package's LICENSE, which only exists inside this monorepo. In a consumer app, each federated package is resolved into its own pub-cache directory and symlinked individually under `ios/.symlinks/plugins/`, so the sibling path is absent and CocoaPods warns on every `pod install` (once per platform podspec):

```
[!] A license was specified in podspec `flutter_email_sender_method_channel` but the file does not exist - .../ios/.symlinks/plugins/flutter_email_sender/LICENSE
[!] Unable to read the license file `../../flutter_email_sender/LICENSE` for the spec `flutter_email_sender_method_channel (0.0.1)`
```

The `flutter_email_sender_method_channel` package already ships its own `LICENSE` at its root, so `../LICENSE` (relative to the `ios/`/`macos/` podspec dir) is the correct target.

## Verification

Replicated CocoaPods' license-file check (resolve `:file` relative to the podspec directory) in a real consumer `.symlinks` layout:

| path | resolves to | exists? |
|------|-------------|---------|
| `../../flutter_email_sender/LICENSE` (old) | `.symlinks/plugins/flutter_email_sender/LICENSE` | ❌ → warning |
| `../LICENSE` (new) | `.symlinks/plugins/flutter_email_sender_method_channel/LICENSE` | ✅ → no warning |

Both paths still resolve inside the monorepo, so nothing regresses there.

## Notes

- No CHANGELOG entry added — release notes in this repo are curated per-version by the maintainer at release time; happy to add one under whichever version you prefer.

Fixes #128
